### PR TITLE
Fix install-oss-cad-suite for tagged releases

### DIFF
--- a/dist/install-oss-cad-suite
+++ b/dist/install-oss-cad-suite
@@ -7,7 +7,7 @@ cd $RUNNER_TEMP
 mkdir -p .setup-oss-cad-suite
 pushd .setup-oss-cad-suite
 if [ -n "$2" ]; then
-    build=`curl -s https://api.github.com/repos/YosysHQ/oss-cad-suite-build/releases/tags/$1 | grep browser_download_url | grep $1 | cut -f4 -d\"`
+    build=`curl -s https://api.github.com/repos/YosysHQ/oss-cad-suite-build/releases/tags/$2 | grep browser_download_url | grep $1 | cut -f4 -d\"`
 else
     build=`curl -s https://api.github.com/repos/YosysHQ/oss-cad-suite-build/releases/latest | grep browser_download_url | grep $1 | cut -f4 -d\"`
 fi


### PR DESCRIPTION
I don't know how to test Github Actions so I can't be certain this is correct, but I think the recent commit adding support for MacOS [1] broke `install-oss-cad-suite` for tagged releases [2].

From looking at [1], I **think** this is the right fix.

- [1] https://github.com/YosysHQ/setup-oss-cad-suite/commit/c56b769cce04c9cd1edb20653ca863257f751608
- [2] https://github.com/chipsalliance/firrtl/runs/4193279276?check_suite_focus=true#step:3:8